### PR TITLE
fix: use 'npm install' rather than 'npm ci' when installing dependencies in workflow

### DIFF
--- a/.github/workflows/ci-main-codecov.yml
+++ b/.github/workflows/ci-main-codecov.yml
@@ -21,9 +21,7 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies
-        run: |
-          cd web
-          npm ci
+        run: cd web && npm install
 
       - name: Run Jest with coverage
         run: |

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -21,9 +21,7 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies
-        run: |
-          cd web
-          npm ci
+        run: cd web && npm install
 
       - name: Run Jest with coverage
         run: |


### PR DESCRIPTION
### Summary
Briefly describe what this PR changes and why it’s needed.

Fix CI error in main branch
---

### Related Issue
Fixes #54  (add issue number, e.g. #123)

---

### Changes
I don't think codecov is behaving consistently. `npm ci` is more fragile than `npm install`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow dependency installation steps for internal build processes.

---

**Note:** These changes are internal infrastructure updates with no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->