### PR TITLE
fix: fix production signup issue

### DIFF
--- a/web/__tests__/jsdom/signup.test.tsx
+++ b/web/__tests__/jsdom/signup.test.tsx
@@ -1,9 +1,3 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import SignUp from "@/app/signup/page";
-import { signup } from "@/app/signup/actions";
-import { useToast } from "@/hooks/use-toast";
-import { validatePassword } from "@/lib/utils";
-
 // 🧩 Mock external dependencies
 jest.mock("@/hooks/use-toast", () => ({
   useToast: jest.fn(),
@@ -18,13 +12,31 @@ jest.mock("@/lib/utils", () => ({
 }));
 
 jest.mock("@/lib/utils", () => {
-    const actual = jest.requireActual("@/lib/utils");
-    return {
-        ...actual,
-        validatePassword: jest.fn(),
-    };
+  const actual = jest.requireActual("@/lib/utils");
+  return {
+    ...actual,
+    validatePassword: jest.fn(),
+  };
+});
 
-})
+jest.mock("next/navigation", () => ({
+  __esModule: true,
+  useRouter: () => ({
+    push: jest.fn(),
+    prefetch: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+  }),
+  usePathname: () => "",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import { signup } from "@/app/signup/actions";
+import SignUp from "@/app/signup/page";
+import { useToast } from "@/hooks/use-toast";
+import { validatePassword } from "@/lib/utils";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 describe("SignUp Page", () => {
   const mockToast = jest.fn();
@@ -123,7 +135,7 @@ describe("SignUp Page", () => {
   });
 
   it("calls signup and shows success toast when valid form is submitted", async () => {
-    (signup as jest.Mock).mockResolvedValueOnce(undefined);
+    (signup as jest.Mock).mockResolvedValueOnce({ success: true });
 
     render(<SignUp />);
     fireEvent.change(screen.getByLabelText(/username/i), {

--- a/web/__tests__/node/signup.action.ts
+++ b/web/__tests__/node/signup.action.ts
@@ -1,9 +1,8 @@
-
 /**
  * @jest-environment node
  */
 import { signup } from "@/app/signup/actions";
-import { TextEncoder, TextDecoder } from "util";
+import { TextDecoder, TextEncoder } from "util";
 
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder as typeof global.TextDecoder;
@@ -19,7 +18,6 @@ jest.mock("next/cache", () => ({
 }));
 
 import { createClient } from "@/utils/supabase/server";
-import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 describe("signup server action", () => {
@@ -58,9 +56,8 @@ describe("signup server action", () => {
       }),
     });
 
-    await signup({ email: "a@test.com", password: "pw", username: "user" });
+    const result = await signup({ email: "a@test.com", password: "pw", username: "user" });
 
-    expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
-    expect(redirect).toHaveBeenCalledWith("/signin");
+    expect(result).toEqual({ success: true });
   });
 });

--- a/web/src/app/signup/actions.ts
+++ b/web/src/app/signup/actions.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { redirect } from "next/navigation";
-
 import { createClient } from "@/utils/supabase/server";
 
 export async function signup(formData: { email?: string; password?: string; username?: string }) {
@@ -36,6 +34,5 @@ export async function signup(formData: { email?: string; password?: string; user
     }
   }
 
-  //revalidatePath('/', 'layout')
-  redirect("/signin");
+  return { success: true };
 }

--- a/web/src/app/signup/page.tsx
+++ b/web/src/app/signup/page.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/hooks/use-toast";
 import { validatePassword } from "@/lib/utils";
 import { Utensils } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { signup } from "./actions";
 
@@ -18,6 +19,7 @@ const SignUp = () => {
   });
 
   const { toast } = useToast();
+  const router = useRouter();
 
   const [errors, setErrors] = useState({
     username: "",
@@ -89,8 +91,14 @@ const SignUp = () => {
     }
 
     try {
-      await signup(formData);
-      toast({ title: "Account created", description: "Please sign in with your new account." });
+      const result = await signup(formData);
+      if (result.success) {
+        toast({ title: "Account created", description: "Please sign in with your new account." });
+        router.push("/signin");
+      }
+      if (result.error) {
+        toast({ title: result.error.message });
+      }
     } catch (err: unknown) {
       const errMsg = (err as { message: string })?.message || "Signup failed";
       toast({ title: "Signup failed", description: errMsg, variant: "destructive" });


### PR DESCRIPTION
### Summary
Briefly describe what this PR changes and why it’s needed.

---

### Related Issue
Fixes #91 (add issue number, e.g. #123)

---

### Changes
- removed redirect, revalidate cache logic in signup action
- make signup action return `{success:true}` and make client handle the result


---

### Test Evidence
Checked the window location changed to signin after successful signup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Code formatting and import/style cleanup with no change to public APIs.

* **Bug Fixes**
  * Signup now returns an explicit success payload; the UI shows a success toast and then redirects users to the sign-in page. Errors show an error toast with the message.

* **Tests**
  * Tests updated to mock navigation and assert the new signup result contract instead of relying on background revalidation or redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->