### PR TITLE
fix: fix src/app/api/events/[id]/route.ts PATCH function to get id by await

### DIFF
--- a/web/src/app/api/events/[id]/route.ts
+++ b/web/src/app/api/events/[id]/route.ts
@@ -1,8 +1,8 @@
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 
-import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 /**
  * 輔助函數：(與 route.ts 中的版本相同)
@@ -44,9 +44,10 @@ async function getPublicUserId(supabase: SupabaseClient<Database>): Promise<numb
 /**
  * PATCH /api/events/[id]
  */
-export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const supabase = await createClient();
-  const entryId = params.id;
+  const _params = await params;
+  const entryId = _params.id;
   let publicUserId: number;
 
   try {


### PR DESCRIPTION
### Summary
Briefly describe what this PR changes and why it’s needed.
some of nextjs policy forces PATCH / GET functions to get params by async method

---

### Related Issue
Fixes #102  (add issue number, e.g. #123)

---

### Changes
made PATCH get params.id by this
```ts
export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
  const supabase = await createClient();
  const _params = await params;
  const entryId = _params.id;
  let publicUserId: number;
...
```

---


### Review Notes
If there’s something reviewers should pay extra attention to, mention it here.
- Are there any design trade-offs?
- Any part of the code that needs discussion or double-checking?

---

### Test Evidence
- I did manual end-to-end testing of adding recipe to calendar and completing the recipe
<img width="1456" height="877" alt="Screenshot 2025-11-05 at 16 33 29" src="https://github.com/user-attachments/assets/49dbe76e-b75a-4ccd-9bfd-3cb05307f7ef" />

- `npm run build` commend worked well in my environment
<img width="703" height="724" alt="image" src="https://github.com/user-attachments/assets/a1a3285c-8b45-4997-a43c-aaf58467fc80" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal API event endpoint parameter handling to align with platform requirements.

**Note:** This release contains internal technical maintenance with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->