### PR TITLE
fix: set backend url for recommender

### DIFF
--- a/web/src/app/api/recommender/route.tsx
+++ b/web/src/app/api/recommender/route.tsx
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
 
+const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8000";
+
 export async function POST(req: Request) {
   try {
     const { goal, numMeals } = await req.json();
 
     // Call FastAPI backend directly
-    const res = await fetch("http://localhost:8000/recommender", {
+    const res = await fetch(`${BACKEND_URL}/recommender`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ goal, numMeals }),


### PR DESCRIPTION
### Summary
To call python backend from vercel, it shouldn't be localhost
So I used `ngrok` to temporally deploy it somewhere out of my local
.env BACKEND_URL

---

### Related Issue
Fixes # (add issue number, e.g. #123)

---

### Changes
It is okay to not have BACKEND_URL in web/.env
it automatically uses localhost:8000



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend URL configuration to use environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->