### PR TITLE
fix: redirect to /dashboard/recipes after successful signup

### DIFF
--- a/web/__tests__/node/signin.action.ts
+++ b/web/__tests__/node/signin.action.ts
@@ -19,7 +19,11 @@ describe("login server action", () => {
 
   it("returns error when signIn fails", async () => {
     (createClient as jest.Mock).mockResolvedValue({
-      auth: { signInWithPassword: jest.fn().mockResolvedValue({ error: { message: "Invalid credentials" } }) },
+      auth: {
+        signInWithPassword: jest
+          .fn()
+          .mockResolvedValue({ error: { message: "Invalid credentials" } }),
+      },
     });
 
     const result = await login({ email: "a@test.com", password: "pw" });
@@ -37,6 +41,6 @@ describe("login server action", () => {
     await login({ email: "a@test.com", password: "pw" });
 
     expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
-    expect(redirect).toHaveBeenCalledWith("/recipes");
+    expect(redirect).toHaveBeenCalledWith("/dashboard/recipes");
   });
 });

--- a/web/src/app/signin/actions.ts
+++ b/web/src/app/signin/actions.ts
@@ -18,9 +18,9 @@ export async function login(formData: { email?: string; password?: string }) {
   const { error, data: authData } = await supabase.auth.signInWithPassword(data);
 
   if (error) {
-    return { error: error.message }
+    return { error: error.message };
   }
 
   revalidatePath("/", "layout");
-  redirect("/recipes");
+  redirect("/dashboard/recipes");
 }


### PR DESCRIPTION
### Summary
Briefly describe what this PR changes and why it’s needed.
- redirect to /dashboard/recipes after successful signup

---

### Related Issue
Fixes #126  (add issue number, e.g. #123)

---

### Changes
- replaced `/recipes` in signup action and signup action test code

---


### Test Evidence

<img  alt="Screenshot 2025-11-07 at 00 01 10" src="https://github.com/user-attachments/assets/bf2bea1e-9e1d-45c9-a0a6-2f4ceefc7fe7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated post-login redirect destination. Upon successful sign-in, users are now directed to the dashboard recipes page, providing proper navigation and improving the overall authentication experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->